### PR TITLE
Save ratings to statistik.csv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 .env
+node_modules/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "audoraplay",
+  "version": "1.0.0",
+  "main": "server.js",
+  "license": "MIT",
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/public/src/script/player.js
+++ b/public/src/script/player.js
@@ -12,6 +12,7 @@ const filenameInput = document.getElementById('filename');
 const extensions = ['.mp3', '.wav', '.ogg', '.mp4', '.m4a'];
 
 let selectedSrc = '';
+let currentFilename = '';
 
 const userTheme = localStorage.getItem('theme');
 const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
@@ -74,6 +75,7 @@ function checkAudioExists(name, index) {
     .then(res => {
         if (res.ok) {
         selectedSrc = src;
+        currentFilename = `${name}${extensions[index]}`;
         if (modal) {
             modal.style.display = 'block';
         }
@@ -139,6 +141,11 @@ function submitRating() {
         ratingMessage.textContent = 'Bitte eine Bewertung auswählen.';
         return;
     }
+    fetch('/rating', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ filename: currentFilename, rating: value })
+    }).catch(() => {});
     ratingMessage.style.color = 'green';
     ratingMessage.textContent = `Bewertung ${value} gespeichert.`;
     if (ratingSection) {

--- a/server.js
+++ b/server.js
@@ -1,0 +1,30 @@
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.use(express.static(path.join(__dirname, 'public')));
+app.use(express.json());
+
+const statsFile = path.join(__dirname, 'statistik.csv');
+
+app.post('/rating', (req, res) => {
+  const { filename, rating } = req.body;
+  if (!filename || !rating) {
+    return res.status(400).send('Missing data');
+  }
+  const line = `${filename},${rating}\n`;
+  fs.appendFile(statsFile, line, (err) => {
+    if (err) {
+      console.error('Failed to save rating', err);
+      return res.status(500).send('Error');
+    }
+    res.sendStatus(200);
+  });
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- ignore node_modules
- collect rating filename on file check
- send rating to new Express backend
- add Express server that saves ratings to statistik.csv

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `node server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_685857802d2c832585ba9da626d47303